### PR TITLE
feat: strip the leading `v` by default if one exists

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -56,7 +56,7 @@ The `format` method has the following options:
 * `revHashDigits: Int = 6` - the number of digits to be used for the revision hash
 * `dirtySep: String = "-DIRTY"` - will be printed before the dirty hash if the local repository is in modified state
 * `dirtyHashDigits: Int = 8` - the number of digits to be used for the dirty hash
-* `tagModifier: String => String` - allows to modify the git tag, e.g. removing a prefix "v"
+* `tagModifier: String => String` - allows to modify the git tag (By default this strips a leading `v` if one exists. e.g. v1.2.3 -> 1.2.3)
 
 When used with its defaults, the outcome is identical to the version scheme used by mill.
 

--- a/core/src/de/tobiasroeser/mill/vcs/version/VcsState.scala
+++ b/core/src/de/tobiasroeser/mill/vcs/version/VcsState.scala
@@ -1,5 +1,7 @@
 package de.tobiasroeser.mill.vcs.version
 
+import scala.util.Try
+
 case class VcsState(
     currentRevision: String,
     lastTag: Option[String],
@@ -15,7 +17,7 @@ case class VcsState(
       revHashDigits: Int = 6,
       dirtySep: String = "-DIRTY",
       dirtyHashDigits: Int = 8,
-      tagModifier: String => String = t => t
+      tagModifier: String => String = stripV
   ): String = {
     val versionPart = tagModifier(lastTag.getOrElse(noTagFallback))
 
@@ -36,6 +38,19 @@ case class VcsState(
 
     s"$versionPart$commitCountPart$revisionPart$dirtyPart"
   }
+
+  /**
+   * By default we strip the leading v if a user uses it.
+   * Ex. v2.3.2 -> 2.3.2
+   * @param tag the tag to process
+   * @return either the stripped tag or the tag verbatim
+   */
+  def stripV(tag: String): String =
+    tag match {
+      case t if t.startsWith("v") && Try(t.substring(1, 2).toInt).isSuccess =>
+        t.substring(1)
+      case t => t
+    }
 
 }
 

--- a/core/test/src/de/tobiasroeser/mill/vcs/version/VcsStateSpec.scala
+++ b/core/test/src/de/tobiasroeser/mill/vcs/version/VcsStateSpec.scala
@@ -35,13 +35,20 @@ class VcsStateSpec extends AnyFreeSpec {
       }
     }
 
-    "should be able to remove a trailing `v` prefix from the tag" in {
+    "should strip the `v` prefix from the tag by default" in {
       assert(
-        state("v0.7.3", 4, "d23456789")
+        state("v0.7.3", 0).format() === "0.7.3"
+      )
+
+    }
+
+    "should be able to use a tag modifier to change the tag" in {
+      assert(
+        state("v0.7.3", 0, null)
           .format(tagModifier = {
-            case t if t.startsWith("v") && Try(t.substring(1,2).toInt).isSuccess => t.substring(1)
-            case t => t
-          } ) === "0.7.3-4-abcdef-DIRTYd2345678"
+            case t if t.startsWith("v") => t.substring(1) + "v"
+            case t                      => t
+          }) === "0.7.3v"
       )
 
     }


### PR DESCRIPTION
This pr changes the behavior slightly when dealing with leading `v`s.
Previously they were handled verbatim. If you had a git tag with
`v1.2.3`, then your version would be `v1.2.3`. Now by default this
strips the leaving `v` so that if you tag `v1.2.3` your version will be
`1.2.3`.

If the user uses the `tagModifier` then this behavior no longer happens
and they user is in full control of the format still.

ref: #51