### PR TITLE
Support omitting the commit count

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,7 +52,7 @@ The `format` method has the following options:
 
 * `noTagFallback: String = "0.0.0"` - will be used when no tag was found
 * `countSep: String = "-"` - will be printed before the commit count when it is greater than zero
-* `commitCountPad: Byte = 0` - if greater that zero, the commit count will be padded to the given length
+* `commitCountPad: Byte = 0` - if greater than zero, the commit count will be padded to the given length; a negative value results in never adding the commit count
 * `revSep: String = "-"` - will be printed before the revision hash if it is not a tagged revision
 * `revHashDigits: Int = 6` - the number of digits to be used for the revision hash
 * `dirtySep: String = "-DIRTY"` - will be printed before the dirty hash if the local repository is in modified state

--- a/core/src/de/tobiasroeser/mill/vcs/version/VcsState.scala
+++ b/core/src/de/tobiasroeser/mill/vcs/version/VcsState.scala
@@ -24,7 +24,7 @@ case class VcsState(
     val commitCountPart = if (lastTag.isEmpty || commitsSinceLastTag > 0) {
       s"$countSep${if (commitCountPad > 0) {
         (10000000000000L + commitsSinceLastTag).toString().substring(14 - commitCountPad, 14)
-      } else commitsSinceLastTag}"
+      } else if (commitCountPad == 0) commitsSinceLastTag else ""}"
     } else ""
 
     val revisionPart = if (lastTag.isEmpty || commitsSinceLastTag > 0) {

--- a/core/test/src/de/tobiasroeser/mill/vcs/version/VcsStateSpec.scala
+++ b/core/test/src/de/tobiasroeser/mill/vcs/version/VcsStateSpec.scala
@@ -50,7 +50,17 @@ class VcsStateSpec extends AnyFreeSpec {
             case t                      => t
           }) === "0.7.3v"
       )
+    }
 
+    "should not render the commit count when commitCountPad is negative" in {
+      assert(
+        state("0.7.3", 4, "a6ea44d3726", "61568ec80f2465f3f01ea2c7e92273f4fbf94b01")
+          .format(dirtyHashDigits = 8, commitCountPad = -1, countSep = "") === "0.7.3-61568e-DIRTYa6ea44d3"
+      )
+      assert(
+        state("0.7.3", 4, null, "61568ec80f2465f3f01ea2c7e92273f4fbf94b01")
+          .format(dirtyHashDigits = 8, commitCountPad = -1, countSep = "") === "0.7.3-61568e"
+      )
     }
 
     "Example format configs" - {
@@ -72,12 +82,6 @@ class VcsStateSpec extends AnyFreeSpec {
         assert(
           state("5.3.7", 30, null, "618c86095ce483feea2e331cc4e28e6466d634f7")
             .format(dirtyHashDigits = 0, commitCountPad = 4, countSep = ".") === "5.3.7.0030-618c86"
-        )
-      }
-      "Maven SNAPSHOT" in {
-        assert(
-          state("5.3.7", 30, "d23456789", "618c86095ce483feea2e331cc4e28e6466d634f7")
-            .format(dirtyHashDigits = 0, commitCountPad = -1, countSep = "-SNAPSHOT", dirtySep = "", revHashDigits = 0, revSep = "") === "5.3.7-SNAPSHOT"
         )
       }
     }

--- a/core/test/src/de/tobiasroeser/mill/vcs/version/VcsStateSpec.scala
+++ b/core/test/src/de/tobiasroeser/mill/vcs/version/VcsStateSpec.scala
@@ -74,6 +74,12 @@ class VcsStateSpec extends AnyFreeSpec {
             .format(dirtyHashDigits = 0, commitCountPad = 4, countSep = ".") === "5.3.7.0030-618c86"
         )
       }
+      "Maven SNAPSHOT" in {
+        assert(
+          state("5.3.7", 30, "d23456789", "618c86095ce483feea2e331cc4e28e6466d634f7")
+            .format(dirtyHashDigits = 0, commitCountPad = -1, countSep = "-SNAPSHOT", dirtySep = "", revHashDigits = 0, revSep = "") === "5.3.7-SNAPSHOT"
+        )
+      }
     }
 
   }


### PR DESCRIPTION
We handle a negative `commitCountPad` value as request to not render the commit count at all.
