### PR TITLE
New format option `untaggedSuffix`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -58,9 +58,9 @@ The `format` method has the following options:
 * `dirtySep: String = "-DIRTY"` - will be printed before the dirty hash if the local repository is in modified state
 * `dirtyHashDigits: Int = 8` - the number of digits to be used for the dirty hash
 * `tagModifier: String => String` - allows to modify the git tag (By default this strips a leading `v` if one exists. e.g. v1.2.3 -> 1.2.3)
-* `appendSnapshot: String = "" - will append the given string at the end of the version when the current revision is not tagged (e.g. use with `"-SNAPSHOT"` to publish to Maven Snapshot repositories)
+* `untaggedSuffix: String = "" - will append the given string at the end of the version when the current revision is not tagged (e.g. use with `"-SNAPSHOT"` to publish to Maven Snapshot repositories)
 
-When used with its defaults, the outcome is identical to the version scheme used by mill.
+When used with its defaults, the outcome is identical to the version scheme used by Mill.
 
 == Download
 

--- a/README.adoc
+++ b/README.adoc
@@ -58,6 +58,7 @@ The `format` method has the following options:
 * `dirtySep: String = "-DIRTY"` - will be printed before the dirty hash if the local repository is in modified state
 * `dirtyHashDigits: Int = 8` - the number of digits to be used for the dirty hash
 * `tagModifier: String => String` - allows to modify the git tag (By default this strips a leading `v` if one exists. e.g. v1.2.3 -> 1.2.3)
+* `appendSnapshot: String = "" - will append the given string at the end of the version when the current revision is not tagged (e.g. use with `"-SNAPSHOT"` to publish to Maven Snapshot repositories)
 
 When used with its defaults, the outcome is identical to the version scheme used by mill.
 

--- a/core/src/de/tobiasroeser/mill/vcs/version/VcsState.scala
+++ b/core/src/de/tobiasroeser/mill/vcs/version/VcsState.scala
@@ -17,17 +17,20 @@ case class VcsState(
       revHashDigits: Int = 6,
       dirtySep: String = "-DIRTY",
       dirtyHashDigits: Int = 8,
-      tagModifier: String => String = stripV
+      tagModifier: String => String = stripV,
+      appendSnapshot: String = ""
   ): String = {
     val versionPart = tagModifier(lastTag.getOrElse(noTagFallback))
 
-    val commitCountPart = if (lastTag.isEmpty || commitsSinceLastTag > 0) {
+    val isUntagged = lastTag.isEmpty || commitsSinceLastTag > 0
+
+    val commitCountPart = if (isUntagged) {
       s"$countSep${if (commitCountPad > 0) {
         (10000000000000L + commitsSinceLastTag).toString().substring(14 - commitCountPad, 14)
       } else commitsSinceLastTag}"
     } else ""
 
-    val revisionPart = if (lastTag.isEmpty || commitsSinceLastTag > 0) {
+    val revisionPart = if (isUntagged) {
       s"$revSep${currentRevision.take(revHashDigits)}"
     } else ""
 
@@ -36,7 +39,9 @@ case class VcsState(
       case Some(d) => dirtySep + d.take(dirtyHashDigits)
     }
 
-    s"$versionPart$commitCountPart$revisionPart$dirtyPart"
+    val snapshotSuffix = if (isUntagged) appendSnapshot else ""
+
+    s"$versionPart$commitCountPart$revisionPart$dirtyPart$snapshotSuffix"
   }
 
   /**

--- a/core/src/de/tobiasroeser/mill/vcs/version/VcsState.scala
+++ b/core/src/de/tobiasroeser/mill/vcs/version/VcsState.scala
@@ -57,6 +57,28 @@ case class VcsState(
       case t => t
     }
 
+  @deprecated("Binary compatibility shim. Use other overload instead.", "mill-vcs-verison after 0.2.0")
+  private[version] def format(
+      noTagFallback: String,
+      countSep: String,
+      commitCountPad: Byte,
+      revSep: String,
+      revHashDigits: Int,
+      dirtySep: String,
+      dirtyHashDigits: Int,
+      tagModifier: String => String
+  ): String = format(
+    noTagFallback = noTagFallback,
+    countSep = countSep,
+    commitCountPad = commitCountPad,
+    revSep = revSep,
+    revHashDigits = revHashDigits,
+    dirtySep = dirtySep,
+    dirtyHashDigits = dirtyHashDigits,
+    tagModifier = tagModifier,
+    appendSnapshot = ""
+  )
+
 }
 
 object VcsState {

--- a/core/src/de/tobiasroeser/mill/vcs/version/VcsState.scala
+++ b/core/src/de/tobiasroeser/mill/vcs/version/VcsState.scala
@@ -18,7 +18,7 @@ case class VcsState(
       dirtySep: String = "-DIRTY",
       dirtyHashDigits: Int = 8,
       tagModifier: String => String = stripV,
-      appendSnapshot: String = ""
+      untaggedSuffix: String = ""
   ): String = {
     val versionPart = tagModifier(lastTag.getOrElse(noTagFallback))
 
@@ -27,7 +27,8 @@ case class VcsState(
     val commitCountPart = if (isUntagged) {
       s"$countSep${if (commitCountPad > 0) {
         (10000000000000L + commitsSinceLastTag).toString().substring(14 - commitCountPad, 14)
-      } else if (commitCountPad == 0) commitsSinceLastTag else ""}"
+      } else if (commitCountPad == 0) commitsSinceLastTag
+      else ""}"
     } else ""
 
     val revisionPart = if (isUntagged) {
@@ -39,7 +40,7 @@ case class VcsState(
       case Some(d) => dirtySep + d.take(dirtyHashDigits)
     }
 
-    val snapshotSuffix = if (isUntagged) appendSnapshot else ""
+    val snapshotSuffix = if (isUntagged) untaggedSuffix else ""
 
     s"$versionPart$commitCountPart$revisionPart$dirtyPart$snapshotSuffix"
   }
@@ -76,7 +77,7 @@ case class VcsState(
     dirtySep = dirtySep,
     dirtyHashDigits = dirtyHashDigits,
     tagModifier = tagModifier,
-    appendSnapshot = ""
+    untaggedSuffix = ""
   )
 
 }

--- a/core/test/src/de/tobiasroeser/mill/vcs/version/VcsStateSpec.scala
+++ b/core/test/src/de/tobiasroeser/mill/vcs/version/VcsStateSpec.scala
@@ -50,7 +50,21 @@ class VcsStateSpec extends AnyFreeSpec {
             case t                      => t
           }) === "0.7.3v"
       )
+    }
 
+    "should append a -SNAPSHOT suffix" in {
+      assert(
+        state("0.7.3", 0, null, "61568ec80f2465f3f01ea2c7e92273f4fbf94b01")
+          .format(appendSnapshot = "-SNAPSHOT") === "0.7.3"
+      )
+      assert(
+        state("0.7.3", 4, "a6ea44d3726", "61568ec80f2465f3f01ea2c7e92273f4fbf94b01")
+          .format(appendSnapshot = "-SNAPSHOT") === "0.7.3-4-61568e-DIRTYa6ea44d3-SNAPSHOT"
+      )
+      assert(
+        state("0.7.3", 4, null, "61568ec80f2465f3f01ea2c7e92273f4fbf94b01")
+          .format(appendSnapshot = "-SNAPSHOT") === "0.7.3-4-61568e-SNAPSHOT"
+      )
     }
 
     "Example format configs" - {

--- a/core/test/src/de/tobiasroeser/mill/vcs/version/VcsStateSpec.scala
+++ b/core/test/src/de/tobiasroeser/mill/vcs/version/VcsStateSpec.scala
@@ -66,15 +66,15 @@ class VcsStateSpec extends AnyFreeSpec {
     "should append a -SNAPSHOT suffix" in {
       assert(
         state("0.7.3", 0, null, "61568ec80f2465f3f01ea2c7e92273f4fbf94b01")
-          .format(appendSnapshot = "-SNAPSHOT") === "0.7.3"
+          .format(untaggedSuffix = "-SNAPSHOT") === "0.7.3"
       )
       assert(
         state("0.7.3", 4, "a6ea44d3726", "61568ec80f2465f3f01ea2c7e92273f4fbf94b01")
-          .format(appendSnapshot = "-SNAPSHOT") === "0.7.3-4-61568e-DIRTYa6ea44d3-SNAPSHOT"
+          .format(untaggedSuffix = "-SNAPSHOT") === "0.7.3-4-61568e-DIRTYa6ea44d3-SNAPSHOT"
       )
       assert(
         state("0.7.3", 4, null, "61568ec80f2465f3f01ea2c7e92273f4fbf94b01")
-          .format(appendSnapshot = "-SNAPSHOT") === "0.7.3-4-61568e-SNAPSHOT"
+          .format(untaggedSuffix = "-SNAPSHOT") === "0.7.3-4-61568e-SNAPSHOT"
       )
     }
 


### PR DESCRIPTION
When publishing artifacts to Maven Snapshot repositories, the version needs to end in `-SNAPSHOT`. 

With this addition, we can automatically add such a suffix, while keeping a unique version based on the last tag.