### PR TITLE
Fix codecov upload file selection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Upload scoverage reports to codecov.io
         uses: codecov/codecov-action@v3
         with:
-          files: ./out/core/0.10/scoverage/xmlReport.dest/scoverage.xml, ./out/core/0.9/scoverage/xmlReport.dest/scoverage.xml, ./out/core/0.7/scoverage/xmlReport.dest/scoverage.xml, ./out/core/0.6/scoverage/xmlReport.dest/scoverage.xml
+          files: ./out/core/0.10/scoverage/xmlReport.dest/scoverage.xml,./out/core/0.9/scoverage/xmlReport.dest/scoverage.xml,./out/core/0.7/scoverage/xmlReport.dest/scoverage.xml,./out/core/0.6/scoverage/xmlReport.dest/scoverage.xml
         continue-on-error: true
 
   publish:


### PR DESCRIPTION
Codecov uploader is currently very picky. It does not accept globs nor spaces between files.