### PR TITLE
Support projects not yet under version control

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -81,6 +81,7 @@ trait BaseModule extends CrossScalaModule with PublishModule with ScoverageModul
   }
 
   def publishVersion = VcsVersion.vcsState().format()
+  override def versionScheme: T[Option[VersionScheme]] = T(Option(VersionScheme.EarlySemVer))
 
   override def mimaPreviousVersions = deps.mimaPreviousVersions
   override def mimaPreviousArtifacts: Target[Agg[Dep]] = T {

--- a/build.sc
+++ b/build.sc
@@ -23,7 +23,7 @@ trait Deps {
   def scalaVersion: String
   def testWithMill: Seq[String]
 
-  def mimaPreviousVersions = Seq("0.1.0", "0.1.1", "0.1.2", "0.1.3", "0.1.4", "0.2.0")
+  def mimaPreviousVersions: Seq[String] = Seq()
 
   val millMain = ivy"com.lihaoyi::mill-main:${millVersion}"
   val millMainApi = ivy"com.lihaoyi::mill-main-api:${millVersion}"
@@ -83,6 +83,12 @@ trait BaseModule extends CrossScalaModule with PublishModule with ScoverageModul
   def publishVersion = VcsVersion.vcsState().format()
 
   override def mimaPreviousVersions = deps.mimaPreviousVersions
+  override def mimaPreviousArtifacts: Target[Agg[Dep]] = T {
+    val md = artifactMetadata()
+    Agg.from(
+      mimaPreviousVersions().map(v => ivy"${md.group}:${md.id}:${v}")
+    )
+  }
 
   override def javacOptions = Seq("-source", "1.8", "-target", "1.8", "-encoding", "UTF-8")
   override def scalacOptions = Seq("-target:jvm-1.8", "-encoding", "UTF-8")

--- a/core/src/de/tobiasroeser/mill/vcs/version/Vcs.scala
+++ b/core/src/de/tobiasroeser/mill/vcs/version/Vcs.scala
@@ -1,0 +1,9 @@
+package de.tobiasroeser.mill.vcs.version
+
+case class Vcs(val name: String)
+
+object Vcs {
+  def git = Vcs("git")
+
+  implicit val jsonify: upickle.default.ReadWriter[Vcs] = upickle.default.macroRW
+}

--- a/core/src/de/tobiasroeser/mill/vcs/version/VcsState.scala
+++ b/core/src/de/tobiasroeser/mill/vcs/version/VcsState.scala
@@ -6,7 +6,8 @@ case class VcsState(
     currentRevision: String,
     lastTag: Option[String],
     commitsSinceLastTag: Int,
-    dirtyHash: Option[String]
+    dirtyHash: Option[String],
+    vcs: Option[Vcs]
 ) {
 
   def format(
@@ -58,7 +59,7 @@ case class VcsState(
       case t => t
     }
 
-  @deprecated("Binary compatibility shim. Use other overload instead.", "mill-vcs-verison after 0.2.0")
+  @deprecated("Binary compatibility shim. Use other overload instead.", "mill-vcs-version after 0.2.0")
   private[version] def format(
       noTagFallback: String,
       countSep: String,
@@ -79,9 +80,8 @@ case class VcsState(
     tagModifier = tagModifier,
     untaggedSuffix = ""
   )
-
 }
 
 object VcsState {
-  implicit def jsonify: upickle.default.ReadWriter[VcsState] = upickle.default.macroRW
+  implicit val jsonify: upickle.default.ReadWriter[VcsState] = upickle.default.macroRW
 }

--- a/core/src/de/tobiasroeser/mill/vcs/version/VcsVersion.scala
+++ b/core/src/de/tobiasroeser/mill/vcs/version/VcsVersion.scala
@@ -2,8 +2,8 @@ package de.tobiasroeser.mill.vcs.version
 
 import scala.util.control.NonFatal
 import mill.T
-import mill.define.{Discover, ExternalModule, Module, Task}
-import mill.api.Result
+import mill.define.{Discover, ExternalModule, Input, Module, Task}
+import mill.api.{Logger, Result}
 import os.{CommandResult, SubprocessException}
 
 trait VcsVersion extends Module {
@@ -15,15 +15,15 @@ trait VcsVersion extends Module {
    *
    * @return A tuple of (the latest tag, the calculated version string)
    */
-  def vcsState: T[VcsState] = T.input { calcVcsState()() }
+  def vcsState: Input[VcsState] = T.input { calcVcsState(T.log) }
 
-  private[this] def calcVcsState(): Task[VcsState] = T.task {
+  private[this] def calcVcsState(logger: Logger): VcsState = {
     val curHeadRaw =
       try {
         Option(os.proc("git", "rev-parse", "HEAD").call(cwd = vcsBasePath).out.trim)
       } catch {
         case e: SubprocessException =>
-          T.log.error(s"${vcsBasePath} is not a git repository.")
+          logger.error(s"${vcsBasePath} is not a git repository.")
           None
       }
 

--- a/core/src/de/tobiasroeser/mill/vcs/version/VcsVersion.scala
+++ b/core/src/de/tobiasroeser/mill/vcs/version/VcsVersion.scala
@@ -1,9 +1,8 @@
 package de.tobiasroeser.mill.vcs.version
 
 import scala.util.control.NonFatal
-
 import mill.T
-import mill.define.{Discover, ExternalModule, Module}
+import mill.define.{Discover, ExternalModule, Module, Task}
 import mill.api.Result
 import os.{CommandResult, SubprocessException}
 
@@ -16,69 +15,93 @@ trait VcsVersion extends Module {
    *
    * @return A tuple of (the latest tag, the calculated version string)
    */
-  def vcsState: T[VcsState] = T.input { calcVcsState() }
+  def vcsState: T[VcsState] = T.input { calcVcsState()() }
 
-  private[this] def calcVcsState(): Result[VcsState] = {
-    val curHead = try {
-      os.proc('git, "rev-parse", "HEAD").call(cwd = vcsBasePath).out.trim
-    } catch {
-      case e: SubprocessException =>
-        return Result.Failure(s"${vcsBasePath} is not a git repository.")
-    }
-
-    val exactTag =
+  private[this] def calcVcsState(): Task[VcsState] = T.task {
+    val curHeadRaw =
       try {
-        Option(
-          os.proc("git", "describe", "--exact-match", "--tags", "--always", curHead)
-            .call(cwd = vcsBasePath)
-            .out.text().trim
-        ).filter(_.nonEmpty)
+        Option(os.proc("git", "rev-parse", "HEAD").call(cwd = vcsBasePath).out.trim)
       } catch {
-        case NonFatal(_) => None
+        case e: SubprocessException =>
+          T.log.error(s"${vcsBasePath} is not a git repository.")
+          None
       }
 
-    val lastTag: Option[String] = exactTag.orElse {
-      try {
-        Option(
-          os
-            .proc("git", "describe", "--abbrev=0", "--tags")
-            .call()
-            .out.text().trim
-        ).filter(_.nonEmpty)
-      } catch {
-        case NonFatal(_) => None
-      }
+    curHeadRaw match {
+      case None =>
+        (None, None)
+        VcsState("no-vcs", None, 0, None, None)
+
+      case curHead =>
+        // we have a proper git repo
+
+        val exactTag =
+          try {
+            curHead
+              .map(curHead =>
+                os.proc("git", "describe", "--exact-match", "--tags", "--always", curHead)
+                  .call(cwd = vcsBasePath)
+                  .out
+                  .text()
+                  .trim
+              )
+              .filter(_.nonEmpty)
+          } catch {
+            case NonFatal(_) => None
+          }
+
+        val lastTag: Option[String] = exactTag.orElse {
+          try {
+            Option(
+              os.proc("git", "describe", "--abbrev=0", "--tags")
+                .call()
+                .out
+                .text()
+                .trim()
+            )
+              .filter(_.nonEmpty)
+          } catch {
+            case NonFatal(_) => None
+          }
+        }
+
+        val commitsSinceLastTag =
+          if (exactTag.isDefined) 0
+          else {
+            curHead
+              .map { curHead =>
+                os.proc(
+                  "git",
+                  "rev-list",
+                  curHead,
+                  lastTag match {
+                    case Some(tag) => Seq("--not", tag)
+                    case _         => Seq()
+                  },
+                  "--count"
+                ).call()
+                  .out
+                  .trim
+                  .toInt
+              }
+              .getOrElse(0)
+          }
+
+        val dirtyHashCode: Option[String] = Option(os.proc("git", "diff").call().out.text().trim()).flatMap {
+          case "" => None
+          case s  => Some(Integer.toHexString(s.hashCode))
+        }
+
+//        Result.Success(
+        new VcsState(
+          currentRevision = curHead.getOrElse(""),
+          lastTag = lastTag,
+          commitsSinceLastTag = commitsSinceLastTag,
+          dirtyHash = dirtyHashCode,
+          vcs = Option(Vcs.git)
+        )
+//        )
     }
-
-    val commitsSinceLastTag =
-      if (exactTag.isDefined) 0
-      else {
-        os.proc(
-          'git,
-          "rev-list",
-          curHead,
-          lastTag match {
-            case Some(tag) => Seq("--not", tag)
-            case _         => Seq()
-          },
-          "--count"
-        ).call()
-          .out
-          .trim
-          .toInt
-      }
-
-    val dirtyHashCode: Option[String] = os.proc('git, 'diff).call().out.text.trim() match {
-      case "" => None
-      case s  => Some(Integer.toHexString(s.hashCode))
-    }
-
-    Result.Success(new VcsState(
-      currentRevision = curHead,
-      lastTag = lastTag,
-      commitsSinceLastTag = commitsSinceLastTag,
-      dirtyHash = dirtyHashCode
-    ))
   }
 
 }

--- a/core/src/de/tobiasroeser/mill/vcs/version/VcsVersion.scala
+++ b/core/src/de/tobiasroeser/mill/vcs/version/VcsVersion.scala
@@ -29,7 +29,6 @@ trait VcsVersion extends Module {
 
     curHeadRaw match {
       case None =>
-        (None, None)
         VcsState("no-vcs", None, 0, None, None)
 
       case curHead =>
@@ -92,7 +91,6 @@ trait VcsVersion extends Module {
           case s  => Some(Integer.toHexString(s.hashCode))
         }
 
-//        Result.Success(
         new VcsState(
           currentRevision = curHead.getOrElse(""),
           lastTag = lastTag,
@@ -100,7 +98,6 @@ trait VcsVersion extends Module {
           dirtyHash = dirtyHashCode,
           vcs = Option(Vcs.git)
         )
-//        )
     }
   }
 

--- a/core/test/src/de/tobiasroeser/mill/vcs/version/VcsStateSpec.scala
+++ b/core/test/src/de/tobiasroeser/mill/vcs/version/VcsStateSpec.scala
@@ -10,8 +10,9 @@ class VcsStateSpec extends AnyFreeSpec {
       lastTag: String,
       commitsSinceLastTag: Int,
       dirtyHash: String = null,
-      currentRevision: String = "abcdefghijklmnopqrstuvwxyz"
-  ): VcsState = VcsState(currentRevision, Option(lastTag), commitsSinceLastTag, Option(dirtyHash))
+      currentRevision: String = "abcdefghijklmnopqrstuvwxyz",
+      vcs: String = "git"
+  ): VcsState = VcsState(currentRevision, Option(lastTag), commitsSinceLastTag, Option(dirtyHash), vcs = Option(Vcs(vcs)))
 
   "VcsState.format" - {
     "With default format options" - {
@@ -75,6 +76,12 @@ class VcsStateSpec extends AnyFreeSpec {
       assert(
         state("0.7.3", 4, null, "61568ec80f2465f3f01ea2c7e92273f4fbf94b01")
           .format(untaggedSuffix = "-SNAPSHOT") === "0.7.3-4-61568e-SNAPSHOT"
+      )
+    }
+
+    "should format with fallback tag when no vcs" in {
+      assert(
+        state(null, 0, null, "no-vcs", null).format() === "0.0.0-0-no-vcs"
       )
     }
 

--- a/itest/src/01-simple/build.sc
+++ b/itest/src/01-simple/build.sc
@@ -30,7 +30,10 @@ def initVcs: T[Unit] =
 def verify(): Command[Unit] =
   T.command {
     initVcs()
-    val version = VcsVersion.vcsState().format()
+    val vcsState = VcsVersion.vcsState()
+    assert(vcsState.vcs == Some(Vcs.git))
+
+    val version = vcsState.format()
     T.log.info(s"version=${version}")
     assert(version.startsWith("1.2.3-1-"))
     ()

--- a/itest/src/no-git/build.sc
+++ b/itest/src/no-git/build.sc
@@ -12,11 +12,11 @@ val baseDir = build.millSourcePath
 def verify(): Command[Unit] =
   T.command {
     val vcState = VcsVersion.vcsState()
+    T.log.errorStream.println(s"vcsState: ${vcState}")
+    assert(vcState.vcs == None)
 
-    // TODO currently, we can't control ENV vars in mill-integrationtest
-    // but without setting GIT_DIR, git will automatically detect the outer git repo
-//    val version = vcState.format()
-//    assert(version.startsWith("0.0.0"), s"""Expected: starts with "0.0.0", actual: "$version"""")
-
+    val version = vcState.format()
+    T.log.errorStream.println(s"version: ${version}")
+    assert(version == "0.0.0-0-no-vcs", s"""Expected: "0.0.0-0-no-vcs", actual: "$version"""")
     ()
   }


### PR DESCRIPTION
To check, if the project is properly version controlled, you can
check `vcsState().vcs: Option[Vcs]` value, which is `None`, in case the
project is not under verison control.

This PR breaks binary compatibility with 0.2.x, so the next release will be 0.3.0.