### PR TITLE
Silence stderr from os.proc calls

### DIFF
--- a/core/src/de/tobiasroeser/mill/vcs/version/VcsVersion.scala
+++ b/core/src/de/tobiasroeser/mill/vcs/version/VcsVersion.scala
@@ -40,7 +40,7 @@ trait VcsVersion extends Module {
             curHead
               .map(curHead =>
                 os.proc("git", "describe", "--exact-match", "--tags", "--always", curHead)
-                  .call(cwd = vcsBasePath)
+                  .call(cwd = vcsBasePath, stderr = os.Pipe)
                   .out
                   .text()
                   .trim
@@ -54,7 +54,7 @@ trait VcsVersion extends Module {
           try {
             Option(
               os.proc("git", "describe", "--abbrev=0", "--tags")
-                .call()
+                .call(stderr = os.Pipe)
                 .out
                 .text()
                 .trim()
@@ -79,7 +79,7 @@ trait VcsVersion extends Module {
                     case _         => Seq()
                   },
                   "--count"
-                ).call()
+                ).call(stderr = os.Pipe)
                   .out
                   .trim()
                   .toInt
@@ -87,7 +87,7 @@ trait VcsVersion extends Module {
               .getOrElse(0)
           }
 
-        val dirtyHashCode: Option[String] = Option(os.proc("git", "diff").call().out.text().trim()).flatMap {
+        val dirtyHashCode: Option[String] = Option(os.proc("git", "diff").call(stderr = os.Pipe).out.text().trim()).flatMap {
           case "" => None
           case s  => Some(Integer.toHexString(s.hashCode))
         }

--- a/core/src/de/tobiasroeser/mill/vcs/version/VcsVersion.scala
+++ b/core/src/de/tobiasroeser/mill/vcs/version/VcsVersion.scala
@@ -21,7 +21,7 @@ trait VcsVersion extends Module {
   private[this] def calcVcsState(logger: Logger): VcsState = {
     val curHeadRaw =
       try {
-        Option(os.proc("git", "rev-parse", "HEAD").call(cwd = vcsBasePath).out.trim())
+        Option(os.proc("git", "rev-parse", "HEAD").call(cwd = vcsBasePath, stderr = os.Pipe).out.trim())
       } catch {
         case e: SubprocessException =>
           logger.error(s"${vcsBasePath} is not a git repository.")


### PR DESCRIPTION
These print out `fatal: no tag exactly matches` messages. In the past it printed once, now it prints continuously due to `T.input`s properly polling for changes, which is super annoying