### PR TITLE
Expose `calcVcsState` publicly for external usage

### DIFF
--- a/core/src/de/tobiasroeser/mill/vcs/version/VcsVersion.scala
+++ b/core/src/de/tobiasroeser/mill/vcs/version/VcsVersion.scala
@@ -18,7 +18,7 @@ trait VcsVersion extends Module {
    */
   def vcsState: Input[VcsState] = T.input { calcVcsState(T.log) }
 
-  private[this] def calcVcsState(logger: Logger): VcsState = {
+  def calcVcsState(logger: Logger): VcsState = {
     val curHeadRaw =
       try {
         Option(os.proc("git", "rev-parse", "HEAD").call(cwd = vcsBasePath, stderr = os.Pipe).out.trim())


### PR DESCRIPTION
This is necessary in order to make it conditionally used (e.g. only enabled based on an environment variable), so Mill's own code can take advantage of https://github.com/com-lihaoyi/mill/pull/4091

As an `Task.Input`, it always is present in the task graph even when the value is ignored due to an `if` conditional, meaning it always triggers downstream tasks and tests during selective execution. Whereas as a helper method I can guard against its usage in an `if` statement (e.g. checking a `sys.env` variable), and if it isn't used it never ends up in the build graph at all