### PR TITLE
bugfix: All git cmds should be run with cwd=vcsBasePath

### DIFF
--- a/core/src/de/tobiasroeser/mill/vcs/version/VcsVersion.scala
+++ b/core/src/de/tobiasroeser/mill/vcs/version/VcsVersion.scala
@@ -54,7 +54,7 @@ trait VcsVersion extends Module {
           try {
             Option(
               os.proc("git", "describe", "--abbrev=0", "--tags")
-                .call(stderr = os.Pipe)
+                .call(cwd = vcsBasePath, stderr = os.Pipe)
                 .out
                 .text()
                 .trim()
@@ -79,7 +79,7 @@ trait VcsVersion extends Module {
                     case _         => Seq()
                   },
                   "--count"
-                ).call(stderr = os.Pipe)
+                ).call(cwd = vcsBasePath, stderr = os.Pipe)
                   .out
                   .trim()
                   .toInt
@@ -87,7 +87,9 @@ trait VcsVersion extends Module {
               .getOrElse(0)
           }
 
-        val dirtyHashCode: Option[String] = Option(os.proc("git", "diff").call(stderr = os.Pipe).out.text().trim()).flatMap {
+        val dirtyHashCode: Option[String] = Option(os.proc("git", "diff")
+                                                     .call(cwd = vcsBasePath, stderr = os.Pipe)
+                                                     .out.text().trim()).flatMap {
           case "" => None
           case s  => Some(Integer.toHexString(s.hashCode))
         }


### PR DESCRIPTION
When mill `out/` directory was moved out of srctree by MILL_OUTPUT_DIR env, all git cmds w/o `cwd` set to `vcsBasePath` will be failed.