### PR TITLE
VcsVersion: dirtiness should consider staged files

### DIFF
--- a/core/src/de/tobiasroeser/mill/vcs/version/VcsVersion.scala
+++ b/core/src/de/tobiasroeser/mill/vcs/version/VcsVersion.scala
@@ -87,7 +87,7 @@ trait VcsVersion extends Module {
               .getOrElse(0)
           }
 
-        val dirtyHashCode: Option[String] = Option(os.proc("git", "diff")
+        val dirtyHashCode: Option[String] = Option(os.proc("git", "diff", "HEAD")
                                                      .call(cwd = vcsBasePath, stderr = os.Pipe)
                                                      .out.text().trim()).flatMap {
           case "" => None


### PR DESCRIPTION
Currently if I create a new file it has a `dirtyHash` of `None` even if I stage it, since `git diff` doesn't include staged changes. `git diff HEAD` includes staged and unstaged changes.

If a new file has not been added to git yet, it will continue to not consider it dirty even with this PR.
